### PR TITLE
added depth texture rendering and initial ambient occlusion code

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "shaders": ["interaction", "buildings", "skydome", "basemap", "texture", "normalmap"],
+  "shaders": ["interaction", "buildings", "skydome", "basemap", "texture", "normalmap", "depth", "ambientFromDepth"],
 
   "lib": [
     "lib/earcut.js",
@@ -38,6 +38,8 @@
     "src/render/Basemap.js",
     "src/render/HudRect.js",
     "src/render/NormalMap.js",
+    "src/render/DepthMap.js",
+    "src/render/AmbientMap.js",
 
     "src/basemap/index.js",
     "src/basemap/Grid.js",

--- a/src/render/AmbientMap.js
+++ b/src/render/AmbientMap.js
@@ -1,0 +1,84 @@
+
+render.AmbientMap = {
+
+  viewportSize: 512,
+
+  init: function() {
+    this.shader = new glx.Shader({
+      vertexShader:   Shaders.ambientFromDepth.vertex,
+      fragmentShader: Shaders.ambientFromDepth.fragment,
+      attributes: ["aPosition", "aTexCoord"],
+      uniforms: ["uMatrix", "uInverseTexWidth", "uInverseTexHeight", "uTexIndex"]
+    });
+
+    this.framebuffer = new glx.Framebuffer(this.viewportSize, this.viewportSize);
+    
+    // enable texture filtering for framebuffer texture
+    gl.bindTexture(gl.TEXTURE_2D, this.framebuffer.renderTexture.id);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    
+    this.vertexBuffer   = new glx.Buffer(3, new Float32Array(
+      [-1, -1, 1E-5,
+        1, -1, 1E-5,
+        1,  1, 1E-5, 
+       -1, -1, 1E-5,
+        1,  1, 1E-5,
+       -1,  1, 1E-5]));
+       
+    this.texCoordBuffer = new glx.Buffer(2, new Float32Array(
+      [0,0,
+       1,0,
+       1,1,
+       0,0,
+       1,1,
+       0,1
+      ]));
+  },
+
+  render: function(depthTexture) {
+
+    var
+      shader = this.shader,
+      framebuffer = this.framebuffer;
+
+    gl.viewport(0, 0, this.viewportSize, this.viewportSize);
+    shader.enable();
+    framebuffer.enable();
+
+    gl.clearColor(1.0, 0.0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+
+    var identity = new glx.Matrix();
+    gl.uniformMatrix4fv(shader.uniforms.uMatrix, false, identity.data);
+
+    gl.uniform1f(shader.uniforms.uInverseTexWidth,  1/this.viewportSize);
+    gl.uniform1f(shader.uniforms.uInverseTexHeight, 1/this.viewportSize);
+
+
+    this.vertexBuffer.enable();
+    gl.vertexAttribPointer(shader.attributes.aPosition, this.vertexBuffer.itemSize, gl.FLOAT, false, 0, 0);
+
+    this.texCoordBuffer.enable();
+    gl.vertexAttribPointer(shader.attributes.aTexCoord, this.texCoordBuffer.itemSize, gl.FLOAT, false, 0, 0);
+
+    gl.bindTexture(gl.TEXTURE_2D, depthTexture);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.uniform1i(shader.uniforms.uTexIndex, 0);
+
+    gl.drawArrays(gl.TRIANGLES, 0, this.vertexBuffer.numItems);
+
+    //render.Basemap.render();
+    shader.disable();
+    framebuffer.disable();
+
+    gl.bindTexture(gl.TEXTURE_2D, this.framebuffer.renderTexture.id);
+    gl.generateMipmap(gl.TEXTURE_2D);
+    
+    gl.viewport(0, 0, MAP.width, MAP.height);
+
+  },
+
+  destroy: function() {}
+};

--- a/src/render/DepthMap.js
+++ b/src/render/DepthMap.js
@@ -1,32 +1,28 @@
 
-/* 'NormalMap' renders the surface normals of the current view into a texture.
-   This normal texture can then be used for screen-space effects such as outline rendering
-   and screen-space ambient occlusion (SSAO).
-   
-   TODO: convert normals from world-space to screen-space?
+/* 'DepthMap' renders depth buffer of the current view into a texture. To be compatible with as
+   many devices as possible, this code does not use the WEBGL_depth_texture extension, but
+   instead color-codes the depth value into an ordinary RGB8 texture.
 
+   This depth texture can then be used for effects such as outline rendering, screen-space
+   ambient occlusion (SSAO) and shadow mapping.
+   
 */
-render.NormalMap = {
+render.DepthMap = {
 
   viewportSize: 512,
 
   init: function() {
     this.shader = new glx.Shader({
-      vertexShader: Shaders.normalmap.vertex,
-      fragmentShader: Shaders.normalmap.fragment,
-      attributes: ["aPosition", "aNormal"],
-      uniforms: [/*"uModelMatrix", "uViewMatrix", "uProjMatrix",*/ "uMatrix"]
+      vertexShader: Shaders.depth.vertex,
+      fragmentShader: Shaders.depth.fragment,
+      attributes: ["aPosition"],
+      uniforms: ["uMatrix"]
     });
 
     this.framebuffer = new glx.Framebuffer(this.viewportSize, this.viewportSize);
-
-    // enable texture filtering for framebuffer texture
-    gl.bindTexture(gl.TEXTURE_2D, this.framebuffer.renderTexture.id);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-
   },
 
+  // TODO: throttle calls
   render: function() {
 
     var
@@ -37,8 +33,7 @@ render.NormalMap = {
     shader.enable();
     framebuffer.enable();
 
-    //the color (0.5, 0.5, 1) corresponds to the normal (0, 0, 1), i.e. 'up'.
-    gl.clearColor(0.5, 0.5, 1, 1);
+    gl.clearColor(0.0, 0.0, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     var
@@ -64,17 +59,18 @@ render.NormalMap = {
       item.vertexBuffer.enable();
       gl.vertexAttribPointer(shader.attributes.aPosition, item.vertexBuffer.itemSize, gl.FLOAT, false, 0, 0);
 
-      item.normalBuffer.enable();
-      gl.vertexAttribPointer(shader.attributes.aNormal, item.normalBuffer.itemSize, gl.FLOAT, false, 0, 0);
+      /*item.normalBuffer.enable();
+      gl.vertexAttribPointer(shader.attributes.aNormal, item.normalBuffer.itemSize, gl.FLOAT, false, 0, 0);*/
 
       gl.drawArrays(gl.TRIANGLES, 0, item.vertexBuffer.numItems);
     }
 
+    //render.Basemap.render();
     shader.disable();
     framebuffer.disable();
 
-    gl.bindTexture(gl.TEXTURE_2D, this.framebuffer.renderTexture.id);
-    gl.generateMipmap(gl.TEXTURE_2D);
+    //gl.bindTexture(gl.TEXTURE_2D, this.framebuffer.renderTexture.id);
+    //gl.generateMipmap(gl.TEXTURE_2D);
     
     gl.viewport(0, 0, MAP.width, MAP.height);
 

--- a/src/render/HudRect.js
+++ b/src/render/HudRect.js
@@ -6,7 +6,7 @@ render.HudRect = {
 
   init: function() {
   
-    var geometry = this.createGeometry(this.baseRadius);
+    var geometry = this.createGeometry();
     this.vertexBuffer   = new glx.Buffer(3, new Float32Array(geometry.vertices));
     this.texCoordBuffer = new glx.Buffer(2, new Float32Array(geometry.texCoords));
 
@@ -14,21 +14,13 @@ render.HudRect = {
       vertexShader: Shaders.texture.vertex,
       fragmentShader: Shaders.texture.fragment,
       attributes: ["aPosition", "aTexCoord"],
-      uniforms: [ /*"uModelMatrix", "uViewMatrix", "uProjMatrix",*/ "uMatrix", "uTexIndex", "uColor"]
+      uniforms: [ "uMatrix", "uTexIndex", "uColor"]
     });
 
-/*    Activity.setBusy();
-
-    this.texture = new glx.texture.Image(url, function(image) {
-      Activity.setIdle();
-      if (image) {
-        this.isReady = true;
-      }
-    }.bind(this));*/
     this.isReady = true;
   },
 
-  createGeometry: function(radius) {
+  createGeometry: function() {
     var vertices = [],
         texCoords= [];
     vertices.push(0, 0, 1E-5,
@@ -59,21 +51,11 @@ render.HudRect = {
       shader = this.shader;
 
     shader.enable();
-    //console.log(texture);
-    gl.uniform3fv(shader.uniforms.uColor, [0.5, 0.1, 0.3]);
-
-    /*var modelMatrix = new glx.Matrix();
-    var scale = render.fogRadius/this.baseRadius;
-    modelMatrix.scale(scale, scale, scale);
-
-    gl.uniformMatrix4fv(shader.uniforms.uModelMatrix, false, modelMatrix.data);
-    gl.uniformMatrix4fv(shader.uniforms.uViewMatrix,  false, render.viewMatrix.data);
-    gl.uniformMatrix4fv(shader.uniforms.uProjMatrix,  false, render.projMatrix.data);*/
     
     var identity = new glx.Matrix();
     gl.uniformMatrix4fv(shader.uniforms.uMatrix, false, identity.data);
-
     this.vertexBuffer.enable();
+
     gl.vertexAttribPointer(shader.attributes.aPosition, this.vertexBuffer.itemSize, gl.FLOAT, false, 0, 0);
 
     this.texCoordBuffer.enable();

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -20,8 +20,10 @@ var render = {
     render.SkyDome.init();
     render.Buildings.init();
     render.Basemap.init();
-    //render.HudRect.init();
-    //render.NormalMap.init();
+    render.HudRect.init();
+    render.NormalMap.init();
+    render.DepthMap.init();
+    render.AmbientMap.init();
 
     this.loop = setInterval(function() {
       requestAnimationFrame(function() {
@@ -30,8 +32,14 @@ var render = {
         render.SkyDome.render();
         render.Buildings.render();
         render.Basemap.render();
+
         //render.NormalMap.render();
-        //render.HudRect.render(render.NormalMap.framebuffer.renderTexture.id);
+
+/*
+        render.DepthMap.render();
+        render.AmbientMap.render(render.DepthMap.framebuffer.renderTexture.id);
+        render.HudRect.render(render.AmbientMap.framebuffer.renderTexture.id);
+*/
       }.bind(this));
     }.bind(this), 17);
   },

--- a/src/shader/ambientFromDepth.fs
+++ b/src/shader/ambientFromDepth.fs
@@ -1,0 +1,58 @@
+#ifdef GL_ES
+  precision mediump float;
+#endif
+
+uniform sampler2D uTexIndex;
+uniform float uInverseTexWidth;   //in 1/pixels, e.g. 1/512 if the texture is 512px wide
+uniform float uInverseTexHeight;  //in 1/pixels
+
+varying vec2 vTexCoord;
+
+/* Retrieves the depth value (dx, dy) pixels away from 'pos' from texture 'uTexIndex'. */
+float getDepth(vec2 pos, int dx, int dy)
+{
+  //retrieve the color-coded depth
+  vec4 codedDepth = texture2D(uTexIndex, vec2(pos.s + float(dx) * uInverseTexWidth, 
+                                              pos.t + float(dy) * uInverseTexHeight));
+  //convert back to depth value
+  return codedDepth.x + codedDepth.y/255.0 + codedDepth.z/(255.0*255.0);
+}
+
+
+/* getOcclusionFactor() determines a heuristic factor for how much the fragment at 'pos' 
+ * with depth 'depthHere'is occluded by the fragment that is (dx, dy) texels away from it.
+ * 
+ * The heuristic is as follows:
+ * - if the fragment at (dx, dy) has no depth (i.e. there was nothing rendered there), then
+ *   'here' is not occluded (result 1.0)
+ * - if the fragment at (dx, dy) is further away from the viewer than 'here', then
+ *   'here is not occluded'
+ * - if the fragment at (dx, dy) is closer to the viewer than 'here', then it occluded
+ *   'here' the higher the depth difference between the two locations is.
+*/
+float getOcclusionFactor(float depthHere, vec2 pos, int dx, int dy)
+{
+    float depthThere = getDepth(pos, dx, dy);
+    if (depthThere == 0.0)
+        return 1.0;
+    
+    return depthHere < depthThere ? 1.0 : /*0.99;//*/ depthThere / depthHere;
+}
+
+void main() {
+
+  float depthHere = getDepth(vTexCoord.st, 0, 0);
+  if (depthHere == 0.0)
+  {
+    gl_FragColor = vec4( vec3(0.0), 1.0);
+    return;
+  }
+  
+  float occlusionFactor = 1.0;
+  for (int x = -3; x <= 3; x++)
+    for (int y = -3; y <= 3; y++)
+        occlusionFactor *= getOcclusionFactor(depthHere, vTexCoord.st,  x,  y);
+
+  gl_FragColor = vec4( vec3(occlusionFactor) , 1.0);
+}
+

--- a/src/shader/ambientFromDepth.vs
+++ b/src/shader/ambientFromDepth.vs
@@ -1,0 +1,16 @@
+#ifdef GL_ES
+  precision mediump float;
+#endif
+
+attribute vec4 aPosition;
+attribute vec2 aTexCoord;
+
+uniform mat4 uMatrix;
+
+varying vec2 vTexCoord;
+
+void main() {
+
+  gl_Position = uMatrix * aPosition;
+  vTexCoord = aTexCoord;
+}

--- a/src/shader/depth.fs
+++ b/src/shader/depth.fs
@@ -1,0 +1,28 @@
+#ifdef GL_ES
+  precision mediump float;
+#endif
+
+varying vec4 vPosition;
+
+void main() {
+  float depth = gl_FragCoord.z / gl_FragCoord.w;
+  float z = depth/1500.0;//gl_FragCoord.z;
+  float z1 = fract(z*255.0);
+  float z2 = fract(z1*255.0);
+  float z3 = fract(z2*255.0);
+
+  /* The following biasing is necessary for shadow mapping to work correctly.
+   * Source: http://forum.devmaster.net/t/shader-effects-shadow-mapping/3002
+   * This might be due to the GPU *rounding* the float values to the nearest uint8_t 
+   * instead of *truncating* as would be expected in C/C++ */
+  z  -= 1.0/255.0*z1;
+  z1 -= 1.0/255.0*z2;
+  z2 -= 1.0/255.0*z3;
+  
+  // option 1: this line outputs high-precision (24bit) depth values
+  gl_FragColor = vec4(z, z1, z2, z3);
+  
+  // option 2: this line outputs human-interpretable depth values, but with low precision
+  //gl_FragColor = vec4(z, z, z, 1.0); 
+
+}

--- a/src/shader/depth.vs
+++ b/src/shader/depth.vs
@@ -1,0 +1,15 @@
+#ifdef GL_ES
+  precision mediump float;
+#endif
+
+attribute vec4 aPosition;
+
+uniform mat4 uMatrix;
+varying vec4 vPosition;
+
+
+void main() {
+
+  gl_Position = uMatrix * aPosition;
+  vPosition = uMatrix * aPosition;
+}


### PR DESCRIPTION
This is still preliminary code. An ambient occlusion map is created, but it is not yet used to shade the actual geometry. To see the ambient occlusion map, uncomment lines 39-41 in src/render/index.js.

This commit also removes the extraneous 'radius' parameters in HudRect.js that were incorrectly added by the previous pull request.