### PR TITLE
always render ambient occlusion at half the screen resolution, making…

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,6 +42,7 @@
     "src/render/NormalMap.js",
     "src/render/DepthMap.js",
     "src/render/AmbientMap.js",
+    "src/render/Overlay.js",
 
     "src/basemap/index.js",
     "src/basemap/Tile.js"

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ var OSMBuildings = function(options) {
 
   render.fogColor = options.fogColor ? Color.parse(options.fogColor).toRGBA(true) : FOG_COLOR;
   render.Buildings.showBackfaces = options.showBackfaces;
+  // default to 'true':
+  render.isAmbientOcclusionEnabled = !!((options.renderAmbientOcclusion === undefined) || options.renderAmbientOcclusion);
 
   this.attribution = options.attribution || OSMBuildings.ATTRIBUTION;
 

--- a/src/render/Overlay.js
+++ b/src/render/Overlay.js
@@ -1,0 +1,99 @@
+
+/* 'Overlay' renders part of a texture over the whole viewport.
+   The intended use is for compositing of screen-space effects.
+ */
+render.Overlay = {
+
+  init: function() {
+  
+    var geometry = this.createGeometry();
+    this.vertexBuffer   = new glx.Buffer(3, new Float32Array(geometry.vertices));
+    this.texCoordBuffer = new glx.Buffer(2, new Float32Array(geometry.texCoords));
+
+    this.texHorizontalFraction = 1;
+    this.texVerticalFraction = 1;
+    this.shader = new glx.Shader({
+      vertexShader: Shaders.texture.vertex,
+      fragmentShader: Shaders.texture.fragment,
+      attributes: ["aPosition", "aTexCoord"],
+      uniforms: [ "uMatrix", "uTexIndex", "uColor"]
+    });
+
+    this.isReady = true;
+  },
+
+  createGeometry: function() {
+    var vertices = [],
+        texCoords= [];
+    vertices.push(-1,-1, 1E-5,
+                   1,-1, 1E-5,
+                   1, 1, 1E-5);
+    
+    vertices.push(-1,-1, 1E-5,
+                   1, 1, 1E-5,
+                  -1, 1, 1E-5);
+
+    texCoords.push(0.0,0.0,
+                   1.0,0.0,
+                   1.0,1.0);
+
+    texCoords.push(0.0,0.0,
+                   1.0,1.0,
+                   0.0,1.0);
+
+    return { vertices: vertices , texCoords: texCoords };
+  },
+
+  render: function(texture, tcHorizMin, tcVertMin, tcHorizMax, tcVertMax) {
+    if (!this.isReady) {
+      return;
+    }
+
+    if (tcHorizMin != this.tcHorizMin ||
+        tcHorizMax != this.tcHorizMax ||
+        tcVertMin != this.tcVertMin ||
+        tcVertMax != this.tcVertMax)
+    {
+      console.log("resetting texCoord buffer to", tcHorizMin, tcHorizMax, tcVertMin, tcVertMax);
+      this.texCoordBuffer.destroy();
+      this.texCoordBuffer = new glx.Buffer(2, new Float32Array([
+        tcHorizMin, tcVertMin,
+        tcHorizMax, tcVertMin,
+        tcHorizMax, tcVertMax,
+
+        tcHorizMin, tcVertMin,
+        tcHorizMax, tcVertMax,
+        tcHorizMin, tcVertMax]));
+      
+      this.tcHorizMin = tcHorizMin;
+      this.tcHorizMax = tcHorizMax;
+      this.tcVertMin  = tcVertMin;
+      this.tcVertMax  = tcVertMax;
+    }
+
+    var shader = this.shader;
+
+    shader.enable();
+    
+    var identity = new glx.Matrix();
+    gl.uniformMatrix4fv(shader.uniforms.uMatrix, false, identity.data);
+    this.vertexBuffer.enable();
+
+    gl.vertexAttribPointer(shader.attributes.aPosition, this.vertexBuffer.itemSize, gl.FLOAT, false, 0, 0);
+
+    this.texCoordBuffer.enable();
+    gl.vertexAttribPointer(shader.attributes.aTexCoord, this.texCoordBuffer.itemSize, gl.FLOAT, false, 0, 0);
+
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.uniform1i(shader.uniforms.uTexIndex, 0);
+
+    gl.drawArrays(gl.TRIANGLES, 0, this.vertexBuffer.numItems);
+
+    shader.disable();
+  },
+
+  destroy: function() {
+    this.texture.destroy();
+  }
+};

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -21,6 +21,7 @@ var render = {
     render.Buildings.init();
     render.Basemap.init();
     render.HudRect.init();
+    render.Overlay.init();
     render.NormalMap.init();
     render.DepthMap.init();
     render.AmbientMap.init();
@@ -40,15 +41,25 @@ var render = {
 
         //render.NormalMap.render();
 
-/*
-        render.DepthMap.render();
-        render.AmbientMap.render(render.DepthMap.framebuffer.renderTexture.id);
-        // first=source is ambient map, second=dest is color framebuffer
-        gl.blendFunc(gl.ZERO, gl.SRC_COLOR);
-        gl.enable(gl.BLEND);
-        render.HudRect.render(render.AmbientMap.framebuffer.renderTexture.id);
-        gl.disable(gl.BLEND);
-*/
+        if (render.isAmbientOcclusionEnabled)
+        {
+          render.DepthMap.render();
+          render.AmbientMap.render(render.DepthMap.framebuffer.renderTexture.id);
+          // first=source is ambient map, second=dest is color framebuffer
+          gl.blendFunc(gl.ZERO, gl.SRC_COLOR);
+          gl.enable(gl.BLEND);
+          render.Overlay.render(
+            render.AmbientMap.framebuffer.renderTexture.id,
+            0.5 / render.AmbientMap.textureWidth,
+            0.5 / render.AmbientMap.textureHeight,
+            (render.AmbientMap.usedTextureWidth-0.5) / render.AmbientMap.textureWidth,
+            (render.AmbientMap.usedTextureHeight-0.5)/ render.AmbientMap.textureHeight);
+
+          gl.disable(gl.BLEND);
+        }
+
+          //render.HudRect.render(render.AmbientMap.framebuffer.renderTexture.id);
+
       }.bind(this));
     }.bind(this), 17);
   },


### PR DESCRIPTION
… the effect resolution-independent

- also parses config option to enable ambient occlusion (defaults to 'true')