### PR TITLE
add computation of view trapezoid

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,7 @@
     "src/mesh/index.js",
     "src/mesh/GeoJSON.js",
     "src/mesh/MapPlane.js",
+    "src/mesh/DebugQuad.js",
     "src/mesh/OBJ.js",
 
     "src/format/GeoJSON.js",

--- a/src/mesh/DebugQuad.js
+++ b/src/mesh/DebugQuad.js
@@ -1,0 +1,115 @@
+
+/*
+*/
+
+mesh.DebugQuad = (function() {
+
+  function constructor(options) {
+    options = options || {};
+
+    this.id = options.id;
+    /*if (options.color) {
+      this.color = Color.parse(options.color).toRGBA(true);
+    }*/
+
+    this.v1 = this.v2 = this.v3 = this.v4 = [false, false, false];
+    this.updateGeometry( [0,0,0], [0,0,0], [0,0,0], [0,0,0]);
+    
+
+    this.minZoom = APP.minZoom;
+    this.maxZoom = APP.maxZoom;
+  }
+
+  function areEqual(a, b) {
+    return a[0] === b[0] &&
+           a[1] === b[1] &&
+           a[2] === b[2];
+  }
+
+  constructor.prototype = {
+
+    updateGeometry: function(v1, v2, v3, v4) {
+      if ( areEqual(v1, this.v1) &&
+           areEqual(v2, this.v2) &&
+           areEqual(v3, this.v3) &&
+           areEqual(v4, this.v4))
+         return; //still up-to-date
+
+      this.v1 = v1;
+      this.v2 = v2;
+      this.v3 = v3;
+      this.v4 = v4;
+      
+      if (this.vertexBuffer)
+        this.vertexBuffer.destroy();
+        
+        
+      var vertices = [].concat(v1, v2, v3, v1, v3, v4);
+      this.vertexBuffer = new glx.Buffer(3, new Float32Array(vertices));
+
+      /*
+      this.dummyMapPlaneTexCoords = new glx.Buffer(2, new Float32Array([
+        0.0, 0.0,
+          1, 0.0,
+          1,   1,
+        
+        0.0, 0.0,
+          1,   1,
+        0.0,   1]));*/
+
+      if (this.normalBuffer)
+        this.normalBuffer.destroy();
+        
+      this.normalBuffer = new glx.Buffer(3, new Float32Array([
+        0, 0, 1,
+        0, 0, 1,
+        0, 0, 1,
+        
+        0, 0, 1,
+        0, 0, 1,
+        0, 0, 1]));
+      
+      var color = [1, 0.5, 0.25];
+      if (this.colorBuffer)
+        this.colorBuffer.destroy();
+        
+      this.colorBuffer = new glx.Buffer(3, new Float32Array(
+        [].concat(color, color, color, color, color, color)));
+
+
+      if (this.idColorBuffer)
+        this.idColorBuffer.destroy();
+
+      this.idColorBuffer = new glx.Buffer(3, new Float32Array(
+        [].concat(color, color, color, color, color, color)));
+        
+      //this.numDummyVertices = 6;
+
+      this.isReady = true;
+    },
+
+    // TODO: switch to mesh.transform
+    getMatrix: function() {
+      //var scale = render.fogRadius/this.radius;
+      var modelMatrix = new glx.Matrix();
+      //modelMatrix.scale(scale, scale, scale);
+    
+      return modelMatrix;
+    },
+
+    destroy: function() {
+
+      this.items = null;
+
+      if (this.isReady) {
+        this.vertexBuffer.destroy();
+        this.normalBuffer.destroy();
+        //this.colorBuffer.destroy();
+        //this.idColorBuffer.destroy();
+      }
+    }
+  };
+
+  return constructor;
+
+}());

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,6 +1,133 @@
 
 var render = {
+  
+  /* transforms the 3D vector 'v' according to the transformation matrix 'm'.
+   * Internally, the vector 'v' is interpreted as a 4D vector 
+   * (v[0], v[1], v[2], 1.0) in homogenous coordinates. The transformation is
+   * performed on that vector, yielding a 4D homogenous result vector. That
+   * vector is then converted back to a 3D Euler coordinates by dividing 
+   * by its components by its fourth component */
+  transformVec3: function( m, v) {
+    var x = v[0]*m[0] + v[1]*m[4] + v[2]*m[8]  + 1.0*m[12];
+    var y = v[0]*m[1] + v[1]*m[5] + v[2]*m[9]  + 1.0*m[13];
+    var z = v[0]*m[2] + v[1]*m[6] + v[2]*m[10] + 1.0*m[14];
+    var w = v[0]*m[3] + v[1]*m[7] + v[2]*m[11] + 1.0*m[15];
+    return [x/w, y/w, z/w]; //convert homogenous to Euler coordinates
+  },
+  
+  /* returns the point (in OSMBuildings' local coordinates) on the XY plane (z==0)
+   * that would be draw at viewport  position (screenNdcX, screenNdcY).
+   * That viewport position is given in normalized device coordinates, i.e.
+   * x==-1.0 is the left screen edge, x==+1.0 is the right one, y==-1.0 is the lower
+   * screen edge and y==+1.0 is the upper one.
+   */
+  getIntersectionWithXYPlane: function( screenNdcX, screenNdcY, inverseTransform) {
+    var v1 = this.transformVec3(inverseTransform, [screenNdcX, screenNdcY, 0]);
+    var v2 = this.transformVec3(inverseTransform, [screenNdcX, screenNdcY, 1]);
+    
+    // direction vector from v1 to v2
+    var vDir = [ v2[0] - v1[0],
+                 v2[1] - v1[1],
+                 v2[2] - v1[2]]
+    
+    if (vDir[2] >= 0) // ray would not intersect with the plane
+    {
+      return undefined;
+    }
+    /* ray equation for all world-space points 'p' lying on the screen-space NDC position 
+     * (screenNdcX, screenNdcY) is:  p = v1 + λ*vDirNorm 
+     * For the intersection with the xy-plane (-> z=0) holds: v1[2] + λ*vDirNorm[2] = p[2] = 0.0.
+     * Rearranged, this reads:   */
+    var lambda = -v1[2]/vDir[2];
+    
+    return [ v1[0] + lambda * vDir[0],
+             v1[1] + lambda * vDir[1],
+             v1[2] + lambda * vDir[2] +1.0]; //FIXME: remove debug z-offset "+1.0"
+  },
+  
+  /* converts a 2D position from OSMBuildings' local coordinate system to OSM slippy tile
+   * coordinates for zoom level 'tileZoom'. The results are not integers, but have a 
+   * fractional component. Math.floor(tileX) gives the actual horizontal tile number, 
+   * while (tileX - Math.floor(tileX)) gives the relative position *inside* the tile. */
+  asTilePosition: function( localXY, tileZoom) {
+    var worldX = localXY[0] + MAP.center.x;
+    var worldY = localXY[1] + MAP.center.y;
+    var worldSize = TILE_SIZE*Math.pow(2, MAP.zoom);
+    
+    var tileX = worldX / worldSize * Math.pow(2,tileZoom);
+    var tileY = worldY / worldSize * Math.pow(2,tileZoom);
+    
+    return [ tileX, tileY];
+  },
 
+  /* returns the quadrilateral part of the XY plane that is currently visible on
+   * screen. The quad is returned in OSM tile coordinates for tile zoom level 
+   * 'tileZoomLevel', and thus can directly be used to determine which basemap 
+   * and geometry tiles need to be loaded.
+   * Note: if the horizon is level (as should usually be the case for 
+   * OSMBuildings) then said quad is also a trapezoid. */
+  getViewQuad: function(viewProjectionMatrix, tileZoomLevel) {
+    //FIXME: determine a reasonable value (5000 was chosen rather arbitrarily)
+    var MAX_EDGE_LENGTH = 5000; 
+  
+    function sub3(a,b) { return [a[0]-b[0], a[1]-b[1], a[2]-b[2]];}
+    function add3(a,b) { return [a[0]+b[0], a[1]+b[1], a[2]+b[2]];}
+    function mul3scalar(a,f) { return [a[0]*f, a[1]*f, a[2]*f];}
+    function len3(a)   { return Math.sqrt( a[0]*a[0] + a[1]*a[1] + a[2]*a[2]);}
+    function norm3(a)  { var l = len3(a); return [a[0]/l, a[1]/l, a[2]/l]};
+    
+    var inverse = glx.Matrix.invert(viewProjectionMatrix);
+
+    var vBottomLeft  = this.getIntersectionWithXYPlane(-1, -1, inverse);
+    var vBottomRight = this.getIntersectionWithXYPlane( 1, -1, inverse);
+    var vTopRight    = this.getIntersectionWithXYPlane( 1,  1, inverse);
+    var vTopLeft     = this.getIntersectionWithXYPlane(-1,  1, inverse);
+    
+    
+    /* If even the lower edge of the screen does not intersect with the map plane,
+     * then the map plane is not visible at all.
+     * (Or somebody screwed up the projection matrix, putting view upside-down 
+     *  or something. But in any case we won't attempt to create a view rectangle).
+     */
+    if (!vBottomLeft || !vBottomRight)
+      return undefined;
+    
+    
+    /* The lower screen edge shows the map layer, but the upper one does not.
+     * This usually happens when the camera is close to parallel to the ground
+     * so that the upper screen edge lies above the horizon. This is not a bug
+     * and can legitimately happen. But from a theoretical standpoint, this means 
+     * that the view 'trapezoid' stretches infinitely toward the horizon. Since this
+     * is not a practically useful result - though formally correct - we instead
+     * manually bound that area.*/
+    if (!vTopLeft || !vTopRight)
+    {
+      /* This point is chosen somewhat arbitrarily. It just *has* to lie on the
+       * left edge of the screen. And it *should* be located relatively low
+       * on that edge to ensure it lies below the horizon, but should not be too
+       * close to 'vBottomLeft' to not cause numerical accuracy issues when computing
+       * the vector between this point and 'vBottomLeft'. The value '-0.9' was 
+       * chosen as it fits these criteria quite well, but no effort was made
+       * to guarantee an *optimal* fit.  */
+      var vLeftPoint = this.getIntersectionWithXYPlane(-1, -0.9, inverse);
+      var vLeftDir = norm3(sub3( vLeftPoint, vBottomLeft));
+      vTopLeft = add3( vBottomLeft, mul3scalar(vLeftDir, MAX_EDGE_LENGTH));
+      
+      /* arbitrary point on the right screen edge, subject to the same
+       * requirements as 'vLeftPoint' */
+      var vRightPoint = this.getIntersectionWithXYPlane( 1, -0.9, inverse);
+      var vRightDir = norm3(sub3( vRightPoint, vBottomRight));
+      vTopRight = add3( vBottomRight, mul3scalar(vRightDir, MAX_EDGE_LENGTH));
+    }
+    
+    //return [ vBottomLeft, vBottomRight, vTopRight, vTopLeft];
+    
+    return [this.asTilePosition( vBottomLeft,  tileZoomLevel),
+            this.asTilePosition( vBottomRight, tileZoomLevel),
+            this.asTilePosition( vTopRight,    tileZoomLevel),
+            this.asTilePosition( vTopLeft,     tileZoomLevel)];
+  },
+  
   start: function() {
     this.viewMatrix = new glx.Matrix();
     this.projMatrix = new glx.Matrix();
@@ -26,6 +153,10 @@ var render = {
     render.DepthMap.init();
     render.AmbientMap.init();
     render.Blur.init();
+    
+    //var quad = new mesh.DebugQuad()
+    //quad.updateGeometry( [-100, -100, 1], [100, -100, 1], [100, 100, 1], [-100, 100, 1]);
+    //data.Index.add(quad);
 
     this.loop = setInterval(function() {
       requestAnimationFrame(function() {
@@ -35,6 +166,11 @@ var render = {
         if (MAP.zoom < APP.minZoom || MAP.zoom > APP.maxZoom) {
           return;
         }
+        
+        var viewTrapezoid = this.getViewQuad( this.viewProjMatrix.data, 16);
+        console.log( viewTrapezoid[0], viewTrapezoid[1], viewTrapezoid[2], viewTrapezoid[3] );
+        //quad.updateGeometry(viewTrapezoid[0], viewTrapezoid[1],
+        //                    viewTrapezoid[2], viewTrapezoid[3]);
 
         render.SkyDome.render();
         render.Buildings.render();

--- a/src/util.js
+++ b/src/util.js
@@ -40,8 +40,7 @@ function relax(callback, startIndex, dataLength, chunkSize, delay) {
   }
 }
 
-function getFramebufferConfig(width, height, maxTexSize)
-{
+function getFramebufferConfig(width, height, maxTexSize) {
   var config = {};
   
   config.width = Math.min(glx.util.nextPowerOf2(width),  maxTexSize );
@@ -64,7 +63,3 @@ function getFramebufferConfig(width, height, maxTexSize)
   return config;
 }
 
-function createTextureCoordinateBuffer(framebufferConfig)
-{
-  
-}


### PR DESCRIPTION
View quad generation has been tested and works reliably. I did not know where to put the code, so I preliminarily added it to src/render/index.js. This is likely not a good place, and should be changed to a more suitable location in a later commit.

Note that the view quad does not technically exist (or alternatively would be unbounded) if the upper screen edge lies above the horizon (because then you could theoretically view objects infinitely far away). In this case, the view quad is artificially bounded to a distance of 5000m between the near and far edge, which is not theoretically correct but more practically useful.