### PR TITLE
Added a bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "OSMBuildings",
-  "version": "2.3.1",
   "homepage": "https://github.com/OSMBuildings/OSMBuildings",
   "authors": [
     "Jan Marsch <jama@keks.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "OSMBuildings",
+  "version": "2.3.1",
+  "homepage": "https://github.com/OSMBuildings/OSMBuildings",
+  "authors": [
+    "Jan Marsch <jama@keks.com>"
+  ],
+  "description": "OpenStreetMap building geometry on 2D and 3D maps",
+  "main": "src/index.js",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "osm",
+    "openstreetmap",
+    "building",
+    "3d",
+    "webgl",
+    "obj",
+    "map",
+    "geojson"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This is a first stab at a bower.json. Once this gets merged, we should [register it](http://bower.io/docs/creating-packages/#register)

One thing to note about bower is it uses the git repo's tags, and assumes they are semantically versioned. So, any time a new version of the library is released, to update it in bower, we just need to update the git tag (I think).

Resolves #51 