### PR TITLE
Added a right click event emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ At some point it will fully integrate the Classic 2.5D version.
 
 [Example](http://osmbuildings.org/gl/?lat=40.70614&lon=-74.01039&zoom=17.00&rotation=0&tilt=40)
 
-For the latest information about the project [follow us on Twitter](https://twitter.com/osmbuildings), read [our blog](http://blog.osmbuildings.org), or just mail us at mail@osmbuildings.org. 
+For the latest information about the project [follow us on Twitter](https://twitter.com/osmbuildings), read [our blog](http://blog.osmbuildings.org), or just mail us at mail@osmbuildings.org.
 
 **Not sure which version to use?**
 
@@ -107,7 +107,7 @@ state | boolean | stores map position/rotation in url, default false
 
 method | parameters | description
 --- | --- | ---
-on | type, function | add an event listener, types are: change, resize, pointerdown, pointermove, pointerup 
+on | type, function | add an event listener, types are: change, resize, pointerdown, pointermove, pointerup, contextmenu
 off | type, fn | remove event listener
 setDisabled | boolean | disables any user input
 isDisabled | | check wheether user input is disabled
@@ -128,7 +128,7 @@ getTilt | | gets current tilt
 
 option | value | description
 --- | --- | ---
-baseURL | string | for locating assets, this is relative to calling page 
+baseURL | string | for locating assets, this is relative to calling page
 minZoom | float | minimum allowed zoom
 maxZoom | float | maximum allowed zoom
 attribution | string | attribution, optional

--- a/src/engines/Basemap/Pointer.js
+++ b/src/engines/Basemap/Pointer.js
@@ -21,6 +21,7 @@ var Pointer = function(map, container) {
     this._addListener(container, 'mousedown', this.onMouseDown);
     this._addListener(document, 'mousemove', this.onMouseMove);
     this._addListener(document, 'mouseup', this.onMouseUp);
+    this._addListener(container, 'contextmenu', this.onContextMenu);
     this._addListener(container, 'dblclick', this.onDoubleClick);
     this._addListener(container, 'mousewheel', this.onMouseWheel);
     this._addListener(container, 'DOMMouseScroll', this.onMouseWheel);
@@ -119,6 +120,12 @@ Pointer.prototype = {
     this.map.emit('pointerup', { x: e.clientX, y: e.clientY });
   },
 
+  onContextMenu: function(e) {
+    e.preventDefault();
+    this.map.emit('contextmenu', { x: e.clientX, y: e.clientY })
+    return false;
+  },
+
   onMouseWheel: function(e) {
     cancelEvent(e);
     var delta = 0;
@@ -143,26 +150,26 @@ Pointer.prototype = {
       return;
     }
 
-    /*FIXME: make movement exact, i.e. make the position that 
-     *       appeared at (this.prevX, this.prevY) before appear at 
+    /*FIXME: make movement exact, i.e. make the position that
+     *       appeared at (this.prevX, this.prevY) before appear at
      *       (e.clientX, e.clientY) now.
      */
-    // the constant 0.86 was chosen experimentally for the map movement to be 
+    // the constant 0.86 was chosen experimentally for the map movement to be
     // "pinned" to the cursor movement when the map is shown top-down
-    var scale = 0.86 * Math.pow( 2, -this.map.zoom);    
+    var scale = 0.86 * Math.pow( 2, -this.map.zoom);
     var lngScale = 1/Math.cos( this.map.position.latitude/ 180 * Math.PI);
     var dx = e.clientX - this.prevX;
     var dy = e.clientY - this.prevY;
     var angle = this.map.rotation * Math.PI/180;
-    
+
     var vRight = [ Math.cos(angle),             Math.sin(angle)];
     var vForward=[ Math.cos(angle - Math.PI/2), Math.sin(angle - Math.PI/2)]
-    
-    var dir = add2(  mul2scalar(vRight,    dx), 
+
+    var dir = add2(  mul2scalar(vRight,    dx),
                      mul2scalar(vForward, -dy));
 
-    this.map.setPosition({ 
-      longitude: this.map.position.longitude - dir[0] * scale*lngScale, 
+    this.map.setPosition({
+      longitude: this.map.position.longitude - dir[0] * scale*lngScale,
       latitude:  this.map.position.latitude  + dir[1] * scale });
   },
 


### PR DESCRIPTION
This adds an event emitter for contextmenu (right click), which can be listed to with the normal `map.on`. It also resolves the issue I just made for this, #53 

I don't see any tests in this library, but let me know if I need to add something for this. My editor also removed some whitespace at the end of some lines. I hope that's alright.