### PR TITLE
Fix bug in example map

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -103,7 +103,7 @@
   //***************************************************************************
 
   osmb.on('pointermove', function(e) {
-    var id = osmb.getTarget(e.detail.x, e.detaily, function(id) {
+    var id = osmb.getTarget(e.detail.x, e.detail.y, function(id) {
       if (id) {
         document.body.style.cursor = 'pointer';
         osmb.highlight(id, '#f08000');


### PR DESCRIPTION
The example map (`dist/index.html`) has a bug in the `pointermove` event listener where a accessor operator (dot) is missing.