### PR TITLE
fix Highlight color problem

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -8,5 +8,9 @@ function substituteZCoordinate(points, zValue) {
 }
 
 function clamp(value, min, max) {
+	if(max===undefined)
+	{
+		return value;
+	}
   return Math.min(max, Math.max(value, min));
 }


### PR DESCRIPTION
The problem is that when you highlight a feature, it always turns black.
because "clamp" returns NAN in Qolor constructor. because there is two clamp method in generated js.